### PR TITLE
Make dev builds (like nightlies) their own slots

### DIFF
--- a/edgedbpkg/edgedb/__init__.py
+++ b/edgedbpkg/edgedb/__init__.py
@@ -51,12 +51,24 @@ class EdgeDB(packages.BundledPythonPackage):
     ]
 
     @property
-    def slot(self) -> str:
+    def base_slot(self) -> str:
         if self.version.prerelease:
             stage, no = self.version.prerelease
             return f'{self.version.major}-{stage}{no}'
         else:
             return f'{self.version.major}'
+
+    @property
+    def slot(self) -> str:
+        # We want dev builds (nightlies) to be their separate slot.
+        # Sadly what we're looking for is not present in any pre-parsed fields.
+        v = self.version.text
+        i = v.find(".dev")
+        if i == -1:
+            return self.base_slot
+
+        dev, _rest = v[i + 1:].split("+", 1)
+        return self.base_slot + "-" + dev
 
     def get_bdist_wheel_command(self, build) -> list:
         bindir = build.get_install_path('bin')

--- a/integration/actions/describe-artifact/src/main.ts
+++ b/integration/actions/describe-artifact/src/main.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as process from 'process'
 
-const re = /^(?:\w+)-(\d+(-(dev|alpha|beta|rc)\d+)?).*\.(rpm|deb|img)$/gm;
+const re = /^(?:\w+)-(\d+(-(alpha|beta|rc)\d+)?(-dev\d+)?).*\.(rpm|deb|img|pkg)$/gm;
 
 async function run() {
   try {

--- a/integration/linux/test-systemd/centos-7/Dockerfile
+++ b/integration/linux/test-systemd/centos-7/Dockerfile
@@ -60,7 +60,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.rpm"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.rpm"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 \n\
 yum install -y "${dest}"/edgedb-server-${slot}*.x86_64.rpm\n\

--- a/integration/linux/test-systemd/centos-8/Dockerfile
+++ b/integration/linux/test-systemd/centos-8/Dockerfile
@@ -60,7 +60,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.rpm"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.rpm"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 \n\
 yum install -y "${dest}"/edgedb-server-${slot}*.x86_64.rpm\n\

--- a/integration/linux/test-systemd/debian-buster/Dockerfile
+++ b/integration/linux/test-systemd/debian-buster/Dockerfile
@@ -36,7 +36,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test-systemd/debian-stretch/Dockerfile
+++ b/integration/linux/test-systemd/debian-stretch/Dockerfile
@@ -36,7 +36,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test-systemd/entrypoint-centos.sh
+++ b/integration/linux/test-systemd/entrypoint-centos.sh
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then
     dest+="-${PKG_PLATFORM_VERSION}"
 fi
 
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\.rpm"
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\.rpm"
 slot="$(ls ${dest} | sed -n -E "s/${re}/\1/p")"
 
 yum install -y "${dest}"/edgedb-server-${slot}*.x86_64.rpm

--- a/integration/linux/test-systemd/entrypoint-debian.sh
+++ b/integration/linux/test-systemd/entrypoint-debian.sh
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then
     dest+="-${PKG_PLATFORM_VERSION}"
 fi
 
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\.deb"
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\.deb"
 slot="$(ls ${dest} | sed -n -E "s/${re}/\1/p")"
 echo "SLOT=$slot"
 

--- a/integration/linux/test-systemd/fedora-29/Dockerfile
+++ b/integration/linux/test-systemd/fedora-29/Dockerfile
@@ -35,7 +35,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.rpm"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.rpm"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 \n\
 yum install -y "${dest}"/edgedb-server-${slot}*.x86_64.rpm\n\

--- a/integration/linux/test-systemd/ubuntu-bionic/Dockerfile
+++ b/integration/linux/test-systemd/ubuntu-bionic/Dockerfile
@@ -36,7 +36,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test-systemd/ubuntu-focal/Dockerfile
+++ b/integration/linux/test-systemd/ubuntu-focal/Dockerfile
@@ -36,7 +36,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test-systemd/ubuntu-xenial/Dockerfile
+++ b/integration/linux/test-systemd/ubuntu-xenial/Dockerfile
@@ -36,7 +36,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test/centos-7/Dockerfile
+++ b/integration/linux/test/centos-7/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.rpm"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.rpm"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 \n\
 dist='\''el$releasever'\''\n\

--- a/integration/linux/test/centos-8/Dockerfile
+++ b/integration/linux/test/centos-8/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.rpm"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.rpm"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 \n\
 dist='\''el$releasever'\''\n\

--- a/integration/linux/test/debian-buster/Dockerfile
+++ b/integration/linux/test/debian-buster/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test/debian-stretch/Dockerfile
+++ b/integration/linux/test/debian-stretch/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test/entrypoint-centos.sh
+++ b/integration/linux/test/entrypoint-centos.sh
@@ -14,7 +14,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then
     dest+="-${PKG_PLATFORM_VERSION}"
 fi
 
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\.rpm"
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\.rpm"
 slot="$(ls ${dest} | sed -n -E "s/${re}/\1/p")"
 
 dist='el$releasever'

--- a/integration/linux/test/entrypoint-debian.sh
+++ b/integration/linux/test/entrypoint-debian.sh
@@ -14,7 +14,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then
     dest+="-${PKG_PLATFORM_VERSION}"
 fi
 
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\.deb"
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\.deb"
 slot="$(ls ${dest} | sed -n -E "s/${re}/\1/p")"
 echo "SLOT=$slot"
 

--- a/integration/linux/test/ubuntu-bionic/Dockerfile
+++ b/integration/linux/test/ubuntu-bionic/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test/ubuntu-focal/Dockerfile
+++ b/integration/linux/test/ubuntu-focal/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/linux/test/ubuntu-xenial/Dockerfile
+++ b/integration/linux/test/ubuntu-xenial/Dockerfile
@@ -21,7 +21,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then\n\
     dest+="-${PKG_PLATFORM_VERSION}"\n\
 fi\n\
 \n\
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\\.deb"\n\
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\\.deb"\n\
 slot="$(ls ${dest} | sed -n -E "s/${re}/\\1/p")"\n\
 echo "SLOT=$slot"\n\
 \n\

--- a/integration/macos/test.sh
+++ b/integration/macos/test.sh
@@ -10,7 +10,7 @@ if [ -n "${PKG_PLATFORM_VERSION}" ]; then
     dest+="-${PKG_PLATFORM_VERSION}"
 fi
 
-re="edgedb-server-([[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?).*\.pkg"
+re="edgedb-server-([[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?).*\.pkg"
 slot="$(ls ${dest} | sed -n -E "s/${re}/\1/p")"
 fwpath="/Library/Frameworks/EdgeDB.framework/"
 python="${fwpath}/Versions/${slot}/lib/edgedb-server-${slot}/bin/python3"

--- a/server/containers/aptrepo/makeindex.py
+++ b/server/containers/aptrepo/makeindex.py
@@ -8,7 +8,8 @@ import subprocess
 
 
 slot_regexp = re.compile(
-    r"^(\w+(?:-[a-zA-Z]*)*?)(?:-(\d+(?:-(?:dev|alpha|beta|rc)\d+))?)?$",
+    r"^(\w+(?:-[a-zA-Z]*)*?)"
+    r"(?:-(\d+(?:-(?:alpha|beta|rc)\d+)?(?:-dev\d+)?))?$",
     re.A
 )
 

--- a/server/containers/genrepo/findold.py
+++ b/server/containers/genrepo/findold.py
@@ -10,7 +10,7 @@ import sys
 
 regexp = re.compile(
     r"^(\w+(-[a-zA-Z]*)?)"
-    r"(-\d+(-(dev|alpha|beta|rc)\d+)?)?"
+    r"(-\d+(-(alpha|beta|rc)\d+)?(-dev\d+)?)?"
     r"_([^_]*)_([^.]*)"
     r"(.*)?$",
     re.A
@@ -41,8 +41,8 @@ def main():
 
         pkgname = m.group(1)
         slot = m.group(3)
-        version = m.group(6)
-        revision = m.group(7)
+        version = m.group(7)
+        revision = m.group(8)
         revno, _, subdist = revision.rpartition('~')
 
         if args.subdist and subdist != args.subdist:

--- a/server/containers/genrepo/makeindex.py
+++ b/server/containers/genrepo/makeindex.py
@@ -9,7 +9,7 @@ import sys
 
 regexp = re.compile(
     r"^(\w+(-[a-zA-Z]*)?)"
-    r"(-\d+(-(dev|alpha|beta|rc)\d+)?)?"
+    r"(-\d+(-(alpha|beta|rc)\d+)?(-dev\d+)?)?"
     r"_([^_]*)_([^.]*)"
     r"(.*)?$",
     re.A
@@ -46,8 +46,8 @@ def main():
 
         pkgname = m.group(1)
         slot = m.group(3)
-        version = m.group(6)
-        revision = m.group(7)
+        version = m.group(7)
+        revision = m.group(8)
 
         index.append({
             'basename': pkgname,

--- a/server/containers/genrepo/processincoming.sh
+++ b/server/containers/genrepo/processincoming.sh
@@ -13,7 +13,7 @@ localdir="%%REPO_LOCAL_DIR%%"
 
 list=$1
 basedir="gs://packages.edgedb-infra.magic.io"
-re="^([[:alnum:]]+(-[[:alpha:]][[:alnum:]]*)?)(-[[:digit:]]+(-(dev|alpha|beta|rc)[[:digit:]]+)?)?_([^_]*)_([^.]*)(.*)?$"
+re="^([[:alnum:]]+(-[[:alpha:]][[:alnum:]]*)?)(-[[:digit:]]+(-(alpha|beta|rc)[[:digit:]]+)?(-dev[[:digit:]]+)?)?_([^_]*)_([^.]*)(.*)?$"
 cd "${incomingdir}"
 dists=()
 
@@ -42,8 +42,8 @@ while read -r -u 10 filename; do
     fi
     slot="$(echo ${leafname} | sed -n -E "s/${re}/\3/p")"
     version="$(echo ${leafname} | sed -n -E "s/${re}/\3/p")"
-    release="$(echo ${leafname} | sed -n -E "s/${re}/\7/p")"
-    ext="$(echo ${leafname} | sed -n -E "s/${re}/\8/p")"
+    release="$(echo ${leafname} | sed -n -E "s/${re}/\8/p")"
+    ext="$(echo ${leafname} | sed -n -E "s/${re}/\9/p")"
     subdist=$(echo ${release} | sed 's/[[:digit:]]\+//')
     subdist="${subdist/\~/_}"
     pkgdir="${dist}${subdist/_/.}"

--- a/server/containers/rpmrepo/makeindex.py
+++ b/server/containers/rpmrepo/makeindex.py
@@ -8,7 +8,8 @@ import subprocess
 
 
 slot_regexp = re.compile(
-    r"^(\w+(?:-[a-zA-Z]*)*?)(?:-(\d+(?:-(?:dev|alpha|beta|rc)\d+))?)?$",
+    r"^(\w+(?:-[a-zA-Z]*)*?)"
+    r"(?:-(\d+(?:-(?:alpha|beta|rc)\d+)?(?:-dev\d+)?))?$",
     re.A
 )
 


### PR DESCRIPTION
Changes the version slot from, say, `edgedb-server-1-alpha6` to `edgedb-server-1-alpha6-dev5034`. The dev part is taken directly from the setuptools-scm version scheme, which is the number of commits on the branch. This should make the dev builds effectively monotonic, easy to parse to the human eye, and useful to say, for example: "yeah this EdgeQL syntax is only available since dev6123".