### PR TITLE
Rudimentary Windows support

### DIFF
--- a/edgedbpkg/edgedbcli/install.list
+++ b/edgedbpkg/edgedbcli/install.list
@@ -1,1 +1,1 @@
-{systembindir}/edgedb
+{systembindir}/edgedb{exesuffix}

--- a/integration/win/build.sh
+++ b/integration/win/build.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -Exeo pipefail
+
+pip install -U git+https://github.com/edgedb/metapkg@win
+pip install -U git+https://github.com/edgedb/edgedb-pkg@win
+
+# Circumvent a dubious practice of Windows intercepting
+# bare invocations of "bash" to mean "WSL", since make
+# runs its shells using bare names even if SHELL contains
+# a fully-qualified path.
+shell_path=$(dirname "${SHELL}")
+cp -a "${SHELL}" "${shell_path}/realbash"
+
+extraopts=
+if [ -n "${SRC_REF}" ]; then
+    extraopts+=" --source-ref=${SRC_REF}"
+fi
+
+if [ -n "${PKG_VERSION}" ]; then
+    extraopts+=" --pkg-version=${PKG_VERSION}"
+fi
+
+if [ -n "${PKG_REVISION}" ]; then
+    if [ "${PKG_REVISION}" = "<current-date>" ]; then
+        PKG_REVISION="$(date -u +%Y%m%d%H)"
+    fi
+    extraopts+=" --pkg-revision=${PKG_REVISION}"
+fi
+
+if [ -n "${PKG_SUBDIST}" ]; then
+    extraopts+=" --pkg-subdist=${PKG_SUBDIST}"
+fi
+
+if [ -n "${BUILD_GENERIC}" ]; then
+    extraopts+=" --generic"
+fi
+
+dest="artifacts"
+if [ -n "${PKG_PLATFORM}" ]; then
+    dest+="/${PKG_PLATFORM}"
+fi
+
+if [ -n "${PKG_PLATFORM_VERSION}" ]; then
+    dest+="-${PKG_PLATFORM_VERSION}"
+fi
+
+if [ -z "${PACKAGE}" ]; then
+    PACKAGE="edgedbpkg.edgedb:EdgeDB"
+fi
+
+python -m metapkg build --dest="${dest}" ${extraopts} "${PACKAGE}"
+
+ls -al "${dest}"

--- a/integration/win/publish.sh
+++ b/integration/win/publish.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p "${HOME}/.ssh" && chmod 700 "${HOME}/.ssh"
+if [ -f "${PACKAGE_UPLOAD_SSH_KEY_FILE}" ]; then
+    cp "${PACKAGE_UPLOAD_SSH_KEY_FILE}" "${HOME}/.ssh/id_ed25519"
+else
+    echo "${PACKAGE_UPLOAD_SSH_KEY}" > "${HOME}/.ssh/id_ed25519"
+fi
+chmod 400 "${HOME}/.ssh/id_ed25519"
+
+set -ex
+
+cat <<EOF >"${HOME}/.ssh/config"
+Host upload-packages.edgedb.com
+    Port 2224
+    StrictHostKeyChecking no
+EOF
+
+dest="artifacts"
+key=""
+if [ -n "${PKG_PLATFORM}" ]; then
+    key+="-${PKG_PLATFORM}"
+fi
+if [ -n "${PKG_PLATFORM_VERSION}" ]; then
+    key+="-${PKG_PLATFORM_VERSION}"
+fi
+
+cd "${dest}"
+list=$(mktemp)
+batch=$(mktemp)
+find . -type f -print | sed "s|^\./||" > "${list}"
+chmod g+rw "${list}"
+
+cat <<EOF >${batch}
+put -r * incoming/
+put ${list} incoming/triggers/upload${key}.list
+EOF
+sftp -b "${batch}" uploader@upload-packages.edgedb.com
+
+rm "${list}" "${batch}"


### PR DESCRIPTION
This treats Windows as a Unix-ish target that has all the necessary GNU
tools, Python, Git, Rust etc.

Closes: #5