### PR TITLE
Replace bash-based daemon servicing with a mini Python supervisor

### DIFF
--- a/server/containers/genrepo/Dockerfile
+++ b/server/containers/genrepo/Dockerfile
@@ -6,7 +6,7 @@ ENV REPO_INCOMING_DIR=/var/spool/repo/incoming/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
         apt-get install -y --no-install-recommends \
-            openssh-server bash inoticoming gosu sudo gnupg \
+            openssh-server bash inoticoming gosu gnupg \
             gcc python3-dev python3-setuptools python3-pip libffi-dev \
     && pip3 install boto3 \
     && pip3 install click \

--- a/server/containers/genrepo/Dockerfile
+++ b/server/containers/genrepo/Dockerfile
@@ -6,7 +6,7 @@ ENV REPO_INCOMING_DIR=/var/spool/repo/incoming/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
         apt-get install -y --no-install-recommends \
-            openssh-server bash incron sudo gnupg \
+            openssh-server bash inoticoming gosu sudo gnupg \
             gcc python3-dev python3-setuptools python3-pip libffi-dev \
     && pip3 install boto3 \
     && pip3 install click \
@@ -34,11 +34,10 @@ RUN apt-get update \
 
 COPY config/sshd/* /etc/ssh.default/
 COPY config/gnupg/* /home/repomgr/.gnupg/
-COPY config/incron/incron.allow /etc/
-COPY config/incron/incrontab /var/spool/incron/repomgr
 COPY entrypoint.sh /entrypoint.sh
 COPY fetch_secrets.py /usr/local/bin/
 COPY process_incoming.py /usr/local/bin/
+COPY visor.py /usr/local/bin/
 RUN sed -i -e "s|%%REPO_INCOMING_DIR%%|${REPO_INCOMING_DIR}|g" \
         /usr/local/bin/process_incoming.py \
     && sed -i -e "s|%%REPO_LOCAL_DIR%%|${REPO_LOCAL_DIR}|g" \
@@ -46,8 +45,7 @@ RUN sed -i -e "s|%%REPO_INCOMING_DIR%%|${REPO_INCOMING_DIR}|g" \
 
 RUN chown -R repomgr:repomgr /home/repomgr/.gnupg \
     && chmod 700 /home/repomgr/.gnupg \
-    && chmod 600 /home/repomgr/.gnupg/* \
-    && chmod 600 /var/spool/incron/repomgr
+    && chmod 600 /home/repomgr/.gnupg/*
 
 EXPOSE 22
 

--- a/server/containers/genrepo/config/incron/incron.allow
+++ b/server/containers/genrepo/config/incron/incron.allow
@@ -1,1 +1,0 @@
-repomgr

--- a/server/containers/genrepo/config/incron/incrontab
+++ b/server/containers/genrepo/config/incron/incrontab
@@ -1,1 +1,0 @@
-/var/spool/repo/incoming/triggers/ IN_CLOSE_WRITE /usr/local/bin/process_incoming.py $@/$#

--- a/server/containers/genrepo/entrypoint.sh
+++ b/server/containers/genrepo/entrypoint.sh
@@ -80,7 +80,20 @@ if [ "$(basename $1)" == "sshd" ]; then
         cat "/etc/ssh.default/sshd_config"
     fi
     export PYTHONUNBUFFERED=1
-    /usr/local/bin/visor.py $@
+    /usr/local/bin/visor.py << EOF
+        [sshd]
+        cmd = $@
+        [inoticoming]
+        user = repomgr:repomgr
+        cmd =
+            inoticoming
+            --initialsearch
+            --foreground
+            ${REPO_INCOMING_DIR}/triggers/
+            /usr/local/bin/process_incoming.py
+            triggers/{}
+            \;
+EOF
 else
     exec "$@"
 fi

--- a/server/containers/genrepo/entrypoint.sh
+++ b/server/containers/genrepo/entrypoint.sh
@@ -50,7 +50,7 @@ fetch_secrets.py release-signing- /root/gpg-keys/
 
 if [ -e "/root/gpg-keys/" ]; then
     while IFS= read -r -d '' path; do
-        cat "${path}" | sudo -u repomgr gpg --import
+        cat "${path}" | gosu repomgr:repomgr gpg --import
     done < <(find "/root/gpg-keys/" -maxdepth 1 -type f -print0)
 fi
 

--- a/server/containers/genrepo/process_incoming.py
+++ b/server/containers/genrepo/process_incoming.py
@@ -201,6 +201,7 @@ def put(
 @click.command()
 @click.argument("upload_listing")  # a single file with a listing of many files
 def main(upload_listing: str) -> None:
+    os.chdir(INCOMING_DIR)
     with open(upload_listing) as upload_listing_file:
         uploads = upload_listing_file.read().splitlines()
     os.unlink(upload_listing)
@@ -209,7 +210,6 @@ def main(upload_listing: str) -> None:
     s3 = session.resource("s3")
     bucket = s3.Bucket("edgedb-packages")
     pkg_directories = set()
-    os.chdir(INCOMING_DIR)
     for path_str in uploads:
         path = pathlib.Path(path_str)
         if not path.is_file():

--- a/server/containers/genrepo/visor.py
+++ b/server/containers/genrepo/visor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+from typing import *
+
+import asyncio
+import ctypes
+import ctypes.util
+import datetime
+import os
+import signal
+import subprocess
+import sys
+
+
+FILTER_OUT = ["Did not receive identification string from"]
+PROCESSES = []
+
+
+def out(txt: str, *args: Any, **kwargs: Any) -> None:
+    """A print wrapper with filtering and a timestamp in the front."""
+    for filtered in FILTER_OUT:
+        if filtered in txt:
+            return
+
+    now = datetime.datetime.utcnow()
+    millis = f"{now.microsecond:0>6}"[:3]
+    ts = now.strftime(f"%H:%M:%S.{millis}")
+    print(ts, txt, *args, **kwargs)
+
+
+def ensure_dead_with_parent() -> None:
+    """A last resort measure to make sure this process dies with its parent."""
+    if not sys.platform.startswith("linux"):
+        return
+
+    PR_SET_PDEATHSIG = 1  # include/uapi/linux/prctl.h
+    libc = ctypes.CDLL(ctypes.util.find_library("c"))  # type: ignore
+    libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
+
+
+async def keep_printing(prefix: str, stream: asyncio.StreamReader) -> None:
+    """Print from the stream with a prefix."""
+    while True:
+        line_b = await stream.readline()
+        if not line_b:
+            break
+        out(f"{prefix}: {line_b.decode('utf8')}", end="")
+
+
+async def run(cmd: List[str], user: str = "") -> int:
+    """Run a command and stream its stdout and stderr."""
+    cmd_name, args = cmd[0], cmd[1:]
+    out("Starting", cmd)
+    run_cmd = cmd_name
+    if user:
+        run_cmd = "gosu"
+        args.insert(0, cmd_name)
+        args.insert(0, user)
+    proc = await asyncio.create_subprocess_exec(
+        run_cmd,
+        *args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=ensure_dead_with_parent,
+    )
+    assert proc.stdout
+    assert proc.stderr
+    PROCESSES.append(proc)
+    out("Running", cmd_name, "at", proc.pid)
+    await asyncio.wait(
+        [
+            keep_printing(cmd_name + " OUT", proc.stdout),
+            keep_printing(cmd_name + " ERR", proc.stderr),
+        ]
+    )
+    return await proc.wait()
+
+
+def stop_processes() -> None:
+    out("Received SIGINT or SIGTERM, shutting down...")
+    for proc in PROCESSES:
+        try:
+            proc.terminate()
+        except BaseException:
+            continue
+
+
+async def async_main() -> int:
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, stop_processes)
+    loop.add_signal_handler(signal.SIGTERM, stop_processes)
+
+    commands = [run(sys.argv[1:])]
+
+    if not os.environ.get("SKIP_INOTICOMING"):
+        spool_dir = "/var/spool/repo"
+        inoticoming_cmd_line = [
+            "inoticoming",
+            "--initialsearch",
+            "--foreground",
+            f"{spool_dir}/incoming/triggers/",
+            "/usr/local/bin/process_incoming.py",
+            r"triggers/{}",
+            ";",
+        ]
+        commands.append(run(inoticoming_cmd_line, user="repomgr:repomgr"))
+
+    return_code = 0
+    for coro in asyncio.as_completed(commands):
+        earliest_return_code = await coro
+        if earliest_return_code and return_code == 0:
+            stop_processes()
+            return_code = earliest_return_code
+            loop.call_later(5, sys.exit, return_code)  # time out
+
+    out("Done.")
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(async_main()))

--- a/server/containers/genrepo/visor.py
+++ b/server/containers/genrepo/visor.py
@@ -79,8 +79,9 @@ async def run(cmd: List[str], user: str = "") -> int:
     return await proc.wait()
 
 
-def stop_processes() -> None:
-    out("Received SIGINT or SIGTERM, shutting down...")
+def stop_processes(quiet: bool = False) -> None:
+    if not quiet:
+        out("Received SIGINT or SIGTERM, shutting down...")
     for proc in PROCESSES:
         try:
             proc.terminate()
@@ -109,7 +110,7 @@ async def async_main() -> int:
     for coro in asyncio.as_completed(commands):
         earliest_return_code = await coro
         if earliest_return_code and return_code == 0:
-            stop_processes()
+            stop_processes(quiet=True)
             return_code = earliest_return_code
             loop.call_later(5, sys.exit, return_code)  # time out
 


### PR DESCRIPTION
This also puts inoticoming in place of incrond which was unsafe (its use of `system()` allows for an attacker to execute arbitrary commands by using malicious filenames) and made it impossible to see any logs on AWS CloudWatch. The current approach logs with no buffering, leading to an "almost realtime" stream on CloudWatch.