### PR TITLE
Don't specify group for gosu

### DIFF
--- a/server/containers/aptrepo/entrypoint.sh
+++ b/server/containers/aptrepo/entrypoint.sh
@@ -98,7 +98,7 @@ if [ "$(basename $1)" == "sshd" ]; then
         [sshd]
         cmd = $@
         [inoticoming]
-        user = reprepro:reprepro
+        user = reprepro
         cmd =
             inoticoming
             --initialsearch

--- a/server/containers/genrepo/Dockerfile
+++ b/server/containers/genrepo/Dockerfile
@@ -21,10 +21,12 @@ RUN apt-get update \
     && adduser uploader incoming \
     && mkdir -p $REPO_INCOMING_DIR/triggers \
     && mkdir -p $REPO_INCOMING_DIR/macos-x86_64 \
+    && mkdir -p $REPO_INCOMING_DIR/win-x86_64 \
     && mkdir -p $REPO_INCOMING_DIR/source \
     && chown -R repomgr:incoming $REPO_INCOMING_DIR \
     && chmod g+ws $REPO_INCOMING_DIR \
     && chmod g+ws $REPO_INCOMING_DIR/macos-x86_64 \
+    && chmod g+ws $REPO_INCOMING_DIR/win-x86_64 \
     && chmod g+ws $REPO_INCOMING_DIR/source \
     && chmod g+ws $REPO_INCOMING_DIR/triggers \
     && mkdir -p /etc/ssh/authorized_keys/ \

--- a/server/containers/genrepo/entrypoint.sh
+++ b/server/containers/genrepo/entrypoint.sh
@@ -86,7 +86,7 @@ if [ "$(basename $1)" == "sshd" ]; then
         [sshd]
         cmd = $@
         [inoticoming]
-        user = repomgr:repomgr
+        user = repomgr
         cmd =
             inoticoming
             --initialsearch

--- a/server/containers/rpmrepo/entrypoint.sh
+++ b/server/containers/rpmrepo/entrypoint.sh
@@ -91,7 +91,7 @@ if [ "$(basename $1)" == "sshd" ]; then
         [sshd]
         cmd = $@
         [inoticoming]
-        user = repomgr:repomgr
+        user = repomgr
         cmd =
             inoticoming
             --initialsearch


### PR DESCRIPTION
When specifying a group for gosu, other applicable groups for the user are no
longer checked. This broke genrepo but was invalid in all three uploaders.