### PR TITLE
Fix installref regression in genrepo

### DIFF
--- a/server/containers/genrepo/process_incoming.py
+++ b/server/containers/genrepo/process_incoming.py
@@ -147,6 +147,9 @@ def make_index(bucket: s3.Bucket, prefix: pathlib.Path, pkg_dir: str) -> None:
 
         basename = m.group("basename")
         slot = m.group("slot") or ""
+        installref = obj.key
+        if not installref.startswith('/'):
+            installref = f'/{installref}'
 
         index["packages"].append(
             Package(
@@ -156,7 +159,7 @@ def make_index(bucket: s3.Bucket, prefix: pathlib.Path, pkg_dir: str) -> None:
                 version=m.group("version"),
                 revision=m.group("release"),
                 architecture=arch,
-                installref=obj.key,
+                installref=installref,
             )
         )
 


### PR DESCRIPTION
The installref for genrepo artifacts should contain the leading slash.

Fixes: edgedb/edgedb-cli#209