### PR TITLE
non-dockerized genrepo sshd listens on port 22

### DIFF
--- a/integration/linux/upload/entrypoint-linux.sh
+++ b/integration/linux/upload/entrypoint-linux.sh
@@ -18,7 +18,6 @@ set -ex
 cat <<EOF >"${HOME}/.ssh/config"
 Host ${PACKAGE_SERVER}
     User uploader
-    Port 2222
     StrictHostKeyChecking no
 EOF
 

--- a/integration/linux/upload/linux-x86_64/Dockerfile
+++ b/integration/linux/upload/linux-x86_64/Dockerfile
@@ -32,7 +32,6 @@ set -ex\n\
 cat <<EOF >"${HOME}/.ssh/config"\n\
 Host ${PACKAGE_SERVER}\n\
     User uploader\n\
-    Port 2222\n\
     StrictHostKeyChecking no\n\
 EOF\n\
 \n\


### PR DESCRIPTION
Because genrepo runs as a vm under systemd, the sshd listens on the normal port.  2222 was used because: docker