### PR TITLE
Make sure process_incoming is serialized

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     'typing-extensions',
     'tomli',
     'semver',
+    'filelock',
 ]
 
 [project.urls]


### PR DESCRIPTION
`inoticoming` will happily call `process_incoming` concurrently, so make
sure we're properly locking the repos to avoid corruption.
