### PR TITLE
Remove apt_pkg dependency

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -27,3 +27,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 py-modules = ["process_incoming"]
+
+[tool.black]
+line-length = 79
+target-version = ["py39"]


### PR DESCRIPTION
`apt_pkg` is only available as a system package on Debian, which makes
`process_incoming` not very portable, including preventing use of
virtualenvs.  It's not really needed, we can use `semver` sorting
instead in the remaining `apt_pkg` call site.
