### PR TITLE
Revert "Remove apt_pkg dependency (#65)"

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     'tomli',
     'semver',
     'filelock',
+    'python-debian',
 ]
 
 [project.urls]
@@ -31,3 +32,10 @@ py-modules = ["process_incoming"]
 [tool.black]
 line-length = 79
 target-version = ["py39"]
+
+[tool.mypy]
+files = "process_incoming.py"
+python_version = "3.9"
+ignore_missing_imports = true
+show_error_codes = true
+strict = true


### PR DESCRIPTION
This reverts commit 02e4686c3a3cd8a65c93050a0a255c4740e2692b and replaces it with the use of portable `python-debian`.