### PR TITLE
Allow configuring multiple buckets for `process_incoming.py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ ifneq ($(PKG_SUBDIST),)
 	EXTRAENV += -e PKG_SUBDIST="$(PKG_SUBDIST)"
 endif
 
+ifneq ($(PKG_TAGS),)
+	EXTRAENV += -e PKG_TAGS="$(PKG_TAGS)"
+endif
+
 ifneq ($(PKG_INSTALL_REF),)
 	EXTRAENV += -e PKG_INSTALL_REF="$(PKG_INSTALL_REF)"
 endif

--- a/integration/linux/build/centos-7/Dockerfile
+++ b/integration/linux/build/centos-7/Dockerfile
@@ -185,7 +185,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -244,6 +244,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/centos-8/Dockerfile
+++ b/integration/linux/build/centos-8/Dockerfile
@@ -185,7 +185,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -244,6 +244,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/debian-bookworm/Dockerfile
+++ b/integration/linux/build/debian-bookworm/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/debian-bullseye/Dockerfile
+++ b/integration/linux/build/debian-bullseye/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/debian-buster/Dockerfile
+++ b/integration/linux/build/debian-buster/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/entrypoint.sh
+++ b/integration/linux/build/entrypoint.sh
@@ -39,6 +39,10 @@ if [ -n "${PKG_SUBDIST}" ]; then
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"
 fi
 
+if [ -n "${PKG_TAGS}" ]; then
+    extraopts+=" --pkg-tags=${PKG_TAGS}"
+fi
+
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then
     extraopts+=" --extra-optimizations"
 fi

--- a/integration/linux/build/fedora-29/Dockerfile
+++ b/integration/linux/build/fedora-29/Dockerfile
@@ -90,7 +90,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -149,6 +149,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/linux-aarch64/Dockerfile
+++ b/integration/linux/build/linux-aarch64/Dockerfile
@@ -218,7 +218,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -277,6 +277,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/linux-x86_64/Dockerfile
+++ b/integration/linux/build/linux-x86_64/Dockerfile
@@ -218,7 +218,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -277,6 +277,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/linuxmusl-aarch64/Dockerfile
+++ b/integration/linux/build/linuxmusl-aarch64/Dockerfile
@@ -82,6 +82,10 @@ if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
 fi\n\
 \n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
+fi\n\
+\n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\
     extraopts+=" --extra-optimizations"\n\
 fi\n\

--- a/integration/linux/build/linuxmusl-x86_64/Dockerfile
+++ b/integration/linux/build/linuxmusl-x86_64/Dockerfile
@@ -82,6 +82,10 @@ if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
 fi\n\
 \n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
+fi\n\
+\n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\
     extraopts+=" --extra-optimizations"\n\
 fi\n\

--- a/integration/linux/build/rockylinux-9/Dockerfile
+++ b/integration/linux/build/rockylinux-9/Dockerfile
@@ -148,6 +148,10 @@ if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
 fi\n\
 \n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
+fi\n\
+\n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\
     extraopts+=" --extra-optimizations"\n\
 fi\n\

--- a/integration/linux/build/ubuntu-bionic/Dockerfile
+++ b/integration/linux/build/ubuntu-bionic/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/ubuntu-focal/Dockerfile
+++ b/integration/linux/build/ubuntu-focal/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/ubuntu-hirsute/Dockerfile
+++ b/integration/linux/build/ubuntu-hirsute/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\

--- a/integration/linux/build/ubuntu-jammy/Dockerfile
+++ b/integration/linux/build/ubuntu-jammy/Dockerfile
@@ -139,7 +139,7 @@ RUN cd /usr/local/bin \
 	&& ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.2.1
+ENV PYTHON_PIP_VERSION 23.3.1
 
 RUN set -ex; \
 	\
@@ -198,6 +198,10 @@ fi\n\
 \n\
 if [ -n "${PKG_SUBDIST}" ]; then\n\
     extraopts+=" --pkg-subdist=${PKG_SUBDIST}"\n\
+fi\n\
+\n\
+if [ -n "${PKG_TAGS}" ]; then\n\
+    extraopts+=" --pkg-tags=${PKG_TAGS}"\n\
 fi\n\
 \n\
 if [ -n "${EXTRA_OPTIMIZATIONS}" ]; then\n\


### PR DESCRIPTION
The incoming package may now declare which bucket it wants to go in
using an identifier, and a mapping from bucket identifiers to actual
bucket names can be specified in the new `[common.buckets]` config key.
