### PR TITLE
Allow actions to pass in a specific list of tests to run on macos

### DIFF
--- a/integration/macos/test.sh
+++ b/integration/macos/test.sh
@@ -55,8 +55,10 @@ fi
 
 export PATH="${workdir}/bin/:${PATH}"
 
+# ${PKG_TEST_FILES} is specificaly used outside the quote so that it
+# can contain a glob.
 "${workdir}/bin/python3" \
     -m edb.tools --no-devmode test \
-    "${workdir}/data/tests" \
+    "${workdir}/data/tests/"${PKG_TEST_FILES} \
     -e cqa_ -e tools_ \
     --verbose ${dash_j}


### PR DESCRIPTION
The idea here is that it will let us run a more trimmed down list of
tests for macos on x86, where the tests are shockingly slow.