### PR TITLE
Fix edgedb-server after edgedb-ls was added

### DIFF
--- a/edgedbpkg/edgedb/no_install.list
+++ b/edgedbpkg/edgedb/no_install.list
@@ -2,3 +2,5 @@
 {bindir}/edgedb.py
 {bindir}/edb
 {bindir}/edb.py
+{bindir}/edgedb-ls
+{bindir}/edgedb-ls.py


### PR DESCRIPTION
edgedb-server build was broken since I've added `edgedb-ls.py` to `project.scripts` in `pyproject.toml` of the main repo.

This PR just adds these files to no_install list of edgedb-server.