### PR TITLE
Pin setuptools build dep to <70.2.0

### DIFF
--- a/edgedbpkg/edgedb/__init__.py
+++ b/edgedbpkg/edgedb/__init__.py
@@ -80,6 +80,7 @@ class EdgeDB(packages.BundledPythonPackage):
 
     artifact_build_requirements = [
         "pyentrypoint (>=1.0.0)",
+        "pypkg-setuptools (<70.2.0)",
     ]
 
     bundle_deps = [


### PR DESCRIPTION
Setuptools 70.2.0 (and more recently 72.0.0) have various breakage, so
pin to `<70.2.0` for now.
