### PR TITLE
postgresql: Use a tarball source instead of git

### DIFF
--- a/edgedbpkg/postgresql/__init__.py
+++ b/edgedbpkg/postgresql/__init__.py
@@ -18,10 +18,14 @@ class PostgreSQL(packages.BundledCPackage):
     name = packages.canonicalize_name("postgresql-edgedb")
     group = "Applications/Databases"
 
+    _pftp = "https://ftp.postgresql.org/pub/source/v{version}/"
+
     sources = [
         {
-            "url": "git+https://github.com/postgres/postgres.git",
-        },
+            "url": _pftp + "postgresql-{version}.tar.bz2",
+            "csum_url": _pftp + "postgresql-{version}.tar.bz2.sha256",
+            "csum_algo": "sha256",
+        }
     ]
 
     artifact_requirements = [


### PR DESCRIPTION
There's no reason for us to clone the entire Postgres git repo,
especially given that Poetry is using dulwich which is extremely
inefficient about cloning large repos.
