### PR TITLE
Fix for new EdgeDB dependencies

### DIFF
--- a/edgedbpkg/edgedb/__init__.py
+++ b/edgedbpkg/edgedb/__init__.py
@@ -184,6 +184,9 @@ class EdgeDB(packages.BundledPythonPackage):
         repo.register_package_impl("cffi", Cffi)
         repo.register_package_impl("jwcrypto", JWCrypto)
         repo.register_package_impl("edgedb", EdgeDBPython)
+        repo.register_package_impl("maturin", Maturin)
+        repo.register_package_impl("pydantic-core", PyPackageNeedingMaturin)
+        repo.register_package_impl("rpds-py", PyPackageNeedingMaturin)
         return repo
 
     @property
@@ -589,3 +592,17 @@ class EdgeDBPython(packages.PythonPackage):
         entries = super().get_file_no_install_entries(build)
         entries.append("{bindir}/*")
         return entries
+
+
+class Maturin(packages.PythonPackage):
+    executable = "maturin"
+
+    def get_build_tools(self, build: targets.Build) -> dict[str, pathlib.Path]:
+        install_dir = build.get_install_dir(self, relative_to="sourceroot")
+        bin_dir = build.get_install_path("bin").relative_to("/")
+        return {self.executable: install_dir / bin_dir / "maturin"}
+
+
+class PyPackageNeedingMaturin(packages.PythonPackage):
+    def get_dep_commands(self) -> list[str]:
+        return [Maturin.executable]

--- a/edgedbpkg/python/__init__.py
+++ b/edgedbpkg/python/__init__.py
@@ -48,9 +48,9 @@ class Python(packages.BundledCPackage):
     ]
 
     bundle_deps = [
-        openssl.OpenSSL("3.1.5"),
+        openssl.OpenSSL("3.3.1"),
         libb2.LibB2("0.98.1"),
-        libffi.LibFFI("3.4.4"),
+        libffi.LibFFI("3.4.6"),
         libuuid.LibUUID("2.39.3"),
         zlib.Zlib("1.3.1"),
     ]


### PR DESCRIPTION
Depends on edgedb/metapkg#38

* OpenSSL 3.2 required in dependency, upgraded to 3.3
* Include libffi fix in libffi/libffi#764 (>=3.4.5)
* metapkg doesn't include build dependency `bin` directory in `$PATH`, breaking the build of packages needing `maturin`