### PR TITLE
Gate long STATEMENT log in SERIALIZATION error

### DIFF
--- a/edgedbpkg/postgresql/patches/postgresql-edgedb__gate_statement_log-14.patch
+++ b/edgedbpkg/postgresql/patches/postgresql-edgedb__gate_statement_log-14.patch
@@ -1,0 +1,28 @@
+From 33b7d8a7aa52caa5425df91156ee2d64523f5062 Mon Sep 17 00:00:00 2001
+From: Fantix King <fantix.king@gmail.com>
+Date: Fri, 30 Aug 2024 13:34:32 -0400
+Subject: [PATCH 6/6] Gate long STATEMENT log in SERIALIZATION error
+
+---
+ src/backend/utils/error/elog.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/backend/utils/error/elog.c b/src/backend/utils/error/elog.c
+index 8d33686510a..bd3197606d0 100644
+--- a/src/backend/utils/error/elog.c
++++ b/src/backend/utils/error/elog.c
+@@ -3106,7 +3106,10 @@ send_message_to_server_log(ErrorData *edata)
+ 	 */
+ 	if (is_log_level_output(edata->elevel, log_min_error_statement) &&
+ 		debug_query_string != NULL &&
+-		!edata->hide_stmt)
++		!edata->hide_stmt &&
++		// Hide STATEMENT in serialization error if longer than 128 bytes
++		(edata->sqlerrcode != ERRCODE_T_R_SERIALIZATION_FAILURE ||
++			strnlen(debug_query_string, 128) < 128))
+ 	{
+ 		log_line_prefix(&buf, edata);
+ 		appendStringInfoString(&buf, _("STATEMENT:  "));
+-- 
+2.46.0
+

--- a/edgedbpkg/postgresql/patches/postgresql-edgedb__gate_statement_log-15.patch
+++ b/edgedbpkg/postgresql/patches/postgresql-edgedb__gate_statement_log-15.patch
@@ -1,0 +1,28 @@
+From 743774f3da65c2d3035f32781c2bbb04f1918e79 Mon Sep 17 00:00:00 2001
+From: Fantix King <fantix.king@gmail.com>
+Date: Fri, 30 Aug 2024 13:34:32 -0400
+Subject: [PATCH 6/6] Gate long STATEMENT log in SERIALIZATION error
+
+---
+ src/backend/utils/error/elog.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/backend/utils/error/elog.c b/src/backend/utils/error/elog.c
+index 01066832e18..24bd20ce382 100644
+--- a/src/backend/utils/error/elog.c
++++ b/src/backend/utils/error/elog.c
+@@ -2384,6 +2384,11 @@ check_log_of_query(ErrorData *edata)
+ 	if (debug_query_string == NULL)
+ 		return false;
+ 
++	// Hide STATEMENT in serialization error if longer than 128 bytes
++	if (edata->sqlerrcode == ERRCODE_T_R_SERIALIZATION_FAILURE
++		&& strnlen(debug_query_string, 128) >= 128)
++		return false;
++
+ 	return true;
+ }
+ 
+-- 
+2.46.0
+

--- a/edgedbpkg/postgresql/patches/postgresql-edgedb__gate_statement_log-16.patch
+++ b/edgedbpkg/postgresql/patches/postgresql-edgedb__gate_statement_log-16.patch
@@ -1,0 +1,28 @@
+From a1f48b8e5f6595488c88f49e2b06d6ebe66ff90f Mon Sep 17 00:00:00 2001
+From: Fantix King <fantix.king@gmail.com>
+Date: Fri, 30 Aug 2024 13:34:32 -0400
+Subject: [PATCH 6/6] Gate long STATEMENT log in SERIALIZATION error
+
+---
+ src/backend/utils/error/elog.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/backend/utils/error/elog.c b/src/backend/utils/error/elog.c
+index 893f8a5b563..8bd84808a7d 100644
+--- a/src/backend/utils/error/elog.c
++++ b/src/backend/utils/error/elog.c
+@@ -2701,6 +2701,11 @@ check_log_of_query(ErrorData *edata)
+ 	if (debug_query_string == NULL)
+ 		return false;
+ 
++	// Hide STATEMENT in serialization error if longer than 128 bytes
++	if (edata->sqlerrcode == ERRCODE_T_R_SERIALIZATION_FAILURE
++		&& strnlen(debug_query_string, 128) >= 128)
++		return false;
++
+ 	return true;
+ }
+ 
+-- 
+2.46.0
+


### PR DESCRIPTION
This patch drops STATEMENT longer than 128 bytes in the log of serialization errors.