### PR TITLE
Fix Ubuntu bionic (bundled OpenSSL)

### DIFF
--- a/edgedbpkg/edgedb/__init__.py
+++ b/edgedbpkg/edgedb/__init__.py
@@ -288,9 +288,15 @@ class EdgeDB(packages.BundledPythonPackage):
 
         openssl_pkg = build.get_package("openssl")
         if build.is_bundled(openssl_pkg):
-            openssl_path = build.get_install_dir(
-                openssl_pkg, relative_to="buildroot"
-            )
+            try:
+                openssl_path = build.get_install_dir(
+                    openssl_pkg, relative_to="buildroot"
+                )
+            except ValueError:
+                # deb/build.py doesn't have buildroot
+                openssl_path = build.get_install_dir(
+                    openssl_pkg, relative_to="pkgsource"
+                )
             openssl_path /= build.get_full_install_prefix().relative_to("/")
             quoted = shlex.quote(str(openssl_path))
             pwd = "$(pwd -P)"


### PR DESCRIPTION
Ubuntu bionic also uses bundled OpenSSL, the relative search path seems to be different. Without this PR, we get [this error](https://github.com/edgedb/edgedb/actions/runs/10747507342/job/29810025945#step:3:4161):

```
  invalid relative_to argument: buildroot

  at /usr/local/lib/python3.9/site-packages/metapkg/targets/deb/build.py:78 in get_path
       74│             return pathlib.Path("..") / ".." / path
       75│         elif relative_to == "fsroot":
       76│             return (self.get_source_abspath() / path).resolve()
       77│         else:
    →  78│             raise ValueError(f"invalid relative_to argument: {relative_to}")
       79│ 
       80│     def get_spec_root(
       81│         self, *, relative_to: targets.Location = "sourceroot"
       82│     ) -> pathlib.Path:
```

[Sample run with this PR](https://github.com/edgedb/edgedb/actions/runs/10753133964)

(The alternative is to add `buildroot` to `deb/build.py` in metapkg, but I'm not sure of its correctness.)