### PR TITLE
Fix centos:8: yum-plugin-fastestmirror is not installed by default

### DIFF
--- a/integration/linux/build/Dockerfile-centos.template
+++ b/integration/linux/build/Dockerfile-centos.template
@@ -20,9 +20,7 @@ ENV GCC_VERSION 11
 # baseurl. Switch to the archive.kernel.org mirror while we are at it.
 RUN set -ex \
 	&& ulimit -n 1024 \
-%%IF VARIANT=7%%
-	&& sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf \
-%%ENDIF%%
+	&& ( [ -e /etc/yum/pluginconf.d/fastestmirror.conf ] && sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf || true ) \
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|# \?baseurl=http://mirror.centos.org|baseurl=https://archive.kernel.org/centos-vault/|g' /etc/yum.repos.d/CentOS-* \
     && yum update -y \

--- a/integration/linux/build/Dockerfile-centos.template
+++ b/integration/linux/build/Dockerfile-centos.template
@@ -20,7 +20,9 @@ ENV GCC_VERSION 11
 # baseurl. Switch to the archive.kernel.org mirror while we are at it.
 RUN set -ex \
 	&& ulimit -n 1024 \
+%%IF VARIANT=7%%
 	&& sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf \
+%%ENDIF%%
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|# \?baseurl=http://mirror.centos.org|baseurl=https://archive.kernel.org/centos-vault/|g' /etc/yum.repos.d/CentOS-* \
     && yum update -y \

--- a/integration/linux/build/centos-7/Dockerfile
+++ b/integration/linux/build/centos-7/Dockerfile
@@ -24,7 +24,7 @@ ENV GCC_VERSION 11
 # baseurl. Switch to the archive.kernel.org mirror while we are at it.
 RUN set -ex \
 	&& ulimit -n 1024 \
-	&& sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf \
+	&& ( [ -e /etc/yum/pluginconf.d/fastestmirror.conf ] && sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf || true ) \
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|# \?baseurl=http://mirror.centos.org|baseurl=https://archive.kernel.org/centos-vault/|g' /etc/yum.repos.d/CentOS-* \
     && yum update -y \

--- a/integration/linux/build/centos-8/Dockerfile
+++ b/integration/linux/build/centos-8/Dockerfile
@@ -23,6 +23,7 @@ ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
 # baseurl. Switch to the archive.kernel.org mirror while we are at it.
 RUN set -ex \
 	&& ulimit -n 1024 \
+	&& ( [ -e /etc/yum/pluginconf.d/fastestmirror.conf ] && sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf || true ) \
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|# \?baseurl=http://mirror.centos.org|baseurl=https://archive.kernel.org/centos-vault/|g' /etc/yum.repos.d/CentOS-* \
     && yum update -y \

--- a/integration/linux/build/centos-8/Dockerfile
+++ b/integration/linux/build/centos-8/Dockerfile
@@ -23,7 +23,6 @@ ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
 # baseurl. Switch to the archive.kernel.org mirror while we are at it.
 RUN set -ex \
 	&& ulimit -n 1024 \
-	&& sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf \
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|# \?baseurl=http://mirror.centos.org|baseurl=https://archive.kernel.org/centos-vault/|g' /etc/yum.repos.d/CentOS-* \
     && yum update -y \


### PR DESCRIPTION
Fixes https://github.com/edgedb/edgedb/actions/runs/11226917010/job/31208267706#step:2:44