### PR TITLE
Revert "Disable linux musl aarch64 test (#125)"

### DIFF
--- a/integration/linux/test/linuxmusl-aarch64/Dockerfile
+++ b/integration/linux/test/linuxmusl-aarch64/Dockerfile
@@ -164,7 +164,12 @@ adduser -G edgedb -H -D edgedb\n\
 if [ "$1" == "bash" ]; then\n\
     exec /bin/sh\n\
 fi\n\
-\n\' >/entrypoint.sh
+\n\
+exec gosu edgedb:edgedb /edgedb/bin/python3 \\\n\
+    -m edb.tools --no-devmode test \\\n\
+    /edgedb/share/tests \\\n\
+    -e cqa_ -e tools_ \\\n\
+    --verbose ${dash_j}\n\' >/entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This reverts commit f270bde7653724bb8787c5f03c96d1940ef7cb4d.